### PR TITLE
only pass `redirect_uri` param to gigya if specified

### DIFF
--- a/Security/Firewall/GigyaListener.php
+++ b/Security/Firewall/GigyaListener.php
@@ -55,7 +55,10 @@ class GigyaListener extends AbstractAuthenticationListener
         $code = $request->query->get('code');
 
         if (null !== $code) {
-            $this->factory->setRedirectUri($this->router->generate($this->route, array(), true));
+
+            if ($this->route) {
+                $this->factory->setRedirectUri($this->router->generate($this->route, array(), true));
+            }
 
             return $this->authenticationManager->authenticate(new GigyaToken('', $code, $this->providerKey));
         }

--- a/Security/Firewall/GigyaListener.php
+++ b/Security/Firewall/GigyaListener.php
@@ -55,7 +55,6 @@ class GigyaListener extends AbstractAuthenticationListener
         $code = $request->query->get('code');
 
         if (null !== $code) {
-
             if ($this->route) {
                 $this->factory->setRedirectUri($this->router->generate($this->route, array(), true));
             }

--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -30,12 +30,15 @@ class MessageFactory
     {
         $request = new Request(Request::METHOD_POST, '/socialize.login', $this->host);
 
-        $request->setContent(http_build_query(array(
+        $data = array(
             'x_provider'    => $provider,
             'client_id'     => $this->key,
-            'redirect_uri'  => $this->redirectUri,
             'response_type' => 'code'
-        )));
+        );
+        if ($this->redirectUri) {
+            $data['redirect_uri'] = $this->redirectUri;
+        }
+        $request->setContent(http_build_query($data));
 
         return $request;
     }
@@ -45,11 +48,16 @@ class MessageFactory
         $request = new Request(Request::METHOD_POST, '/socialize.getToken?client_id='.$this->key.'&client_secret='.$this->secret, $this->host);
 
         if (null !== $code) {
-            $request->setContent(http_build_query(array(
+
+            $data = array(
                 'grant_type'   => 'authorization_code',
                 'code'         => $code,
-                'redirect_uri' => $this->redirectUri,
-            )));
+            );
+            if ($this->redirectUri) {
+                $data['redirect_uri'] = $this->redirectUri;
+            }
+            $request->setContent(http_build_query($data));
+
         } else {
             $request->setContent(http_build_query(array(
                 'grant_type'   => 'none',

--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -48,7 +48,6 @@ class MessageFactory
         $request = new Request(Request::METHOD_POST, '/socialize.getToken?client_id='.$this->key.'&client_secret='.$this->secret, $this->host);
 
         if (null !== $code) {
-
             $data = array(
                 'grant_type'   => 'authorization_code',
                 'code'         => $code,
@@ -57,7 +56,6 @@ class MessageFactory
                 $data['redirect_uri'] = $this->redirectUri;
             }
             $request->setContent(http_build_query($data));
-
         } else {
             $request->setContent(http_build_query(array(
                 'grant_type'   => 'none',


### PR DESCRIPTION
The [`socialize.getToken`](http://developers.gigya.com/037_API_reference/025_OAuth2_End_Points/socialize.getToken) method requires the same `redirect_uri` as the [`socialize.login`](http://developers.gigya.com/030_Gigya_Socialize_API_2.0/030_API_reference/010_Client_API_%28JavaScript%29/Social_service/socialize.login) (called `redirectURL` there).

Since we handle the login response with JS in our project, we need to omit the `redirectURL`. I added the check for `gigya.redirect_route` and if it isn't set it also isn't sent to Gigya. (an empty url is not accepted by Gigya).
