### PR TITLE
Socializer & MessageFactory improvements

### DIFF
--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -149,7 +149,7 @@ class MessageFactory
         return $request;
     }
 
-    public function getNotifyLoginRequest($token, $id, $newUser = false, $message = null)
+    public function getNotifyLoginRequest($token, $id, $newUser = false, $message = null, $userInfo = null)
     {
         $request = new Request(Request::METHOD_POST, '/socialize.notifyRegistration?'.http_build_query(array(
             'apiKey'    => $this->key,
@@ -165,6 +165,10 @@ class MessageFactory
 
         if (null !== $message) {
             $data['cid'] = $message;
+        }
+
+        if (null !== $userInfo) {
+            $data['userInfo'] = json_encode($userInfo);
         }
 
         $request->setContent(http_build_query($data));

--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -26,6 +26,30 @@ class MessageFactory
         $this->redirectUri = $redirectUri;
     }
 
+    public function getDeleteAccountRequest($token, $id, $message = null)
+    {
+        $request = new Request(Request::METHOD_POST, '/socialize.deleteAccount?'.http_build_query(array(
+            'uid'       => $id,
+            'apiKey'    => $this->key,
+            'secret'    => $this->secret,
+            'nonce'     => $token,
+            'timestamp' => time(),
+        )), $this->host);
+
+        $data = array(
+            'uid' => $id,
+        );
+
+        if (null !== $message) {
+            $data['cid'] = $message;
+        }
+
+        $request->setContent(http_build_query($data));
+
+        return $request;
+    }
+
+
     public function getLoginRequest($provider)
     {
         $request = new Request(Request::METHOD_POST, '/socialize.login', $this->host);

--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -125,7 +125,7 @@ class MessageFactory
         return $request;
     }
 
-    public function getNotifyLoginRequest($token, $id, $message = null)
+    public function getNotifyLoginRequest($token, $id, $newUser = false, $message = null)
     {
         $request = new Request(Request::METHOD_POST, '/socialize.notifyRegistration?'.http_build_query(array(
             'uid'       => $id,
@@ -137,6 +137,7 @@ class MessageFactory
 
         $data = array(
             'siteUID' => $id,
+            'newUser' => $newUser,
         );
 
         if (null !== $message) {

--- a/Socializer/Buzz/MessageFactory.php
+++ b/Socializer/Buzz/MessageFactory.php
@@ -128,7 +128,6 @@ class MessageFactory
     public function getNotifyLoginRequest($token, $id, $newUser = false, $message = null)
     {
         $request = new Request(Request::METHOD_POST, '/socialize.notifyRegistration?'.http_build_query(array(
-            'uid'       => $id,
             'apiKey'    => $this->key,
             'secret'    => $this->secret,
             'nonce'     => $token,

--- a/Socializer/Socializer.php
+++ b/Socializer/Socializer.php
@@ -255,10 +255,10 @@ class Socializer implements SocializerInterface, UserProviderInterface
         return true;
     }
 
-    public function notifyLogin($token, $id, $message = null)
+    public function notifyLogin($token, $id, $newUser = false, $message = null)
     {
         $response = $this->factory->getResponse();
-        $request  = $this->factory->getNotifyLoginRequest($token, $id, $message);
+        $request  = $this->factory->getNotifyLoginRequest($token, $id, $newUser, $message);
 
         $this->client->send($request, $response);
 

--- a/Socializer/Socializer.php
+++ b/Socializer/Socializer.php
@@ -255,10 +255,10 @@ class Socializer implements SocializerInterface, UserProviderInterface
         return true;
     }
 
-    public function notifyLogin($token, $id, $newUser = false, $message = null)
+    public function notifyLogin($token, $id, $newUser = false, $message = null, $userInfo = null)
     {
         $response = $this->factory->getResponse();
-        $request  = $this->factory->getNotifyLoginRequest($token, $id, $newUser, $message);
+        $request  = $this->factory->getNotifyLoginRequest($token, $id, $newUser, $message, $userInfo);
 
         $this->client->send($request, $response);
 

--- a/Socializer/Socializer.php
+++ b/Socializer/Socializer.php
@@ -299,6 +299,38 @@ class Socializer implements SocializerInterface, UserProviderInterface
         return $result;
     }
 
+    /**
+     * Removes the user account at gigya's
+     *
+     * @param   string  $token
+     * @param   string  $id
+     * @param   string  $message
+     *
+     * @return  \SimpleXMLElement   The response
+     * @throws  \Exception  If invalid response or error
+     */
+    public function deleteAccount($token, $id, $message = null)
+    {
+        $response = $this->factory->getResponse();
+        $request  = $this->factory->getDeleteAccountRequest($token, $id, $message);
+
+        $this->client->send($request, $response);
+
+        libxml_use_internal_errors(true);
+
+        $result = simplexml_load_string($response->getContent());
+
+        if (!$result) {
+            throw new \Exception('Gigya API returned invalid response');
+        }
+
+        if ((string) $result->errorCode) {
+            throw new \Exception($result->errorMessage);
+        }
+
+        return $result;
+    }
+
     public function refreshUser(UserInterface $user)
     {
         if (!$user instanceof User) {

--- a/Socializer/Socializer.php
+++ b/Socializer/Socializer.php
@@ -274,7 +274,7 @@ class Socializer implements SocializerInterface, UserProviderInterface
             throw new \Exception($result->errorMessage);
         }
 
-        return true;
+        return $result;
     }
 
     public function getSessionInfo($uid, $provider)

--- a/Socializer/SocializerInterface.php
+++ b/Socializer/SocializerInterface.php
@@ -14,4 +14,5 @@ interface SocializerInterface
     function getUser($token);
     function getSessionInfo($uid, $provider);
     function notifyRegistration($token, $uid, $id, $message = null);
+    function deleteAccount($token, $id, $message = null);
 }


### PR DESCRIPTION
This fixes a few issues with the gigya communication and adds the `socialize.deleteUser` API call. See full commit messages for more info.

As for returning the response in `Socializer#notifyLogin()`, we need that since [it is required](http://developers.gigya.com/037_API_reference/020_REST_API/socialize.notifyLogin#tab-2) to set the cookie which is provided by the response.

We also have a method called `setCookieFromResponse(\SimpleXMLElement $response)` which takes this response and creates a cookie. I can send a PR if you think it should be part of this bundle (and whether it should go into `Socializer`, or maybe `Helper/SocializerHelper`).
